### PR TITLE
Clear most hurdles to AOT deployment

### DIFF
--- a/Scribal.Cli/Features/ChapterDrafterService.cs
+++ b/Scribal.Cli/Features/ChapterDrafterService.cs
@@ -232,7 +232,7 @@ public class ChapterDrafterService(
             }
             catch (Exception e)
             {
-                console.WriteException(e);
+                ExceptionDisplay.DisplayException(e, console);
                 console.MarkupLine("[red]An error occurred during refinement.[/]");
                 logger.LogError(e, "Error during draft refinement for {RefinementCid}", refinementCid);
             }

--- a/Scribal.Cli/Features/ChapterManagerService.cs
+++ b/Scribal.Cli/Features/ChapterManagerService.cs
@@ -4,6 +4,7 @@ using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.IO.Abstractions;
 using Microsoft.Extensions.Logging;
+using Scribal.Cli.Interface;
 using Scribal.Workspace;
 using Spectre.Console;
 
@@ -323,7 +324,7 @@ public class ChapterManagerService(
 
             if (deletionResult.Exception != null && deletionResult.Exception is not OperationCanceledException)
             {
-                AnsiConsole.WriteException(deletionResult.Exception);
+                ExceptionDisplay.DisplayException(deletionResult.Exception);
             }
         }
     }

--- a/Scribal.Cli/Features/CommandService.cs
+++ b/Scribal.Cli/Features/CommandService.cs
@@ -141,7 +141,7 @@ public class CommandService(
         catch (Exception e)
         {
             AnsiConsole.MarkupLine("[red]An unexpected error occurred during export.[/]");
-            AnsiConsole.WriteException(e);
+            ExceptionDisplay.DisplayException(e);
         }
     }
 
@@ -163,7 +163,7 @@ public class CommandService(
         }
         catch (Exception e)
         {
-            AnsiConsole.WriteException(e);
+            ExceptionDisplay.DisplayException(e);
         }
     }
 
@@ -202,7 +202,7 @@ public class CommandService(
         catch (Exception e)
         {
             AnsiConsole.MarkupLine("[red]An unexpected error occurred while committing.[/]");
-            AnsiConsole.WriteException(e);
+            ExceptionDisplay.DisplayException(e);
         }
     }
 
@@ -224,7 +224,7 @@ public class CommandService(
         }
         catch (Exception e)
         {
-            AnsiConsole.WriteException(e);
+            ExceptionDisplay.DisplayException(e);
         }
     }
 
@@ -245,7 +245,7 @@ public class CommandService(
         }
         catch (Exception e)
         {
-            AnsiConsole.WriteException(e);
+            ExceptionDisplay.DisplayException(e);
         }
     }
 

--- a/Scribal.Cli/Features/NewChapterCreator.cs
+++ b/Scribal.Cli/Features/NewChapterCreator.cs
@@ -309,7 +309,7 @@ public class NewChapterCreator(
             }
             catch (Exception e)
             {
-                console.WriteException(e);
+                ExceptionDisplay.DisplayException(e, console);
                 console.MarkupLine("[red]An error occurred during refinement.[/]");
                 logger.LogError(e, "Error during draft refinement for {RefinementCid}", refinementCid);
             }

--- a/Scribal.Cli/Features/OutlineService.cs
+++ b/Scribal.Cli/Features/OutlineService.cs
@@ -321,7 +321,7 @@ public class OutlineService(
             }
             catch (Exception e)
             {
-                AnsiConsole.WriteException(e);
+                ExceptionDisplay.DisplayException(e);
                 AnsiConsole.MarkupLine("[red]An error occurred during refinement.[/]");
 
                 // Potentially remove the last user message if the turn failed

--- a/Scribal.Cli/Features/OutlineService.cs
+++ b/Scribal.Cli/Features/OutlineService.cs
@@ -145,7 +145,7 @@ public class OutlineService(
 
         try
         {
-            outline = JsonSerializer.Deserialize<StoryOutline>(actualJson, JsonDefaults.Default);
+            outline = JsonSerializer.Deserialize<StoryOutline>(actualJson, JsonDefaults.Context.StoryOutline);
 
             return outline?.Chapters is {Count: > 0};
         }

--- a/Scribal.Cli/Features/PitchService.cs
+++ b/Scribal.Cli/Features/PitchService.cs
@@ -168,7 +168,7 @@ public class PitchService(
             }
             catch (Exception e)
             {
-                console.WriteException(e);
+                ExceptionDisplay.DisplayException(e, console);
                 console.MarkupLine("[red]An error occurred during refinement.[/]");
 
                 return false;

--- a/Scribal.Cli/Features/WorkspaceDeleter.cs
+++ b/Scribal.Cli/Features/WorkspaceDeleter.cs
@@ -2,6 +2,7 @@ using System.CommandLine.Invocation;
 using System.IO.Abstractions;
 using Microsoft.Extensions.Logging;
 using Scribal.Agency;
+using Scribal.Cli.Interface;
 using Scribal.Workspace;
 using Spectre.Console;
 
@@ -109,7 +110,7 @@ public class WorkspaceDeleter(
                     {
                         console.MarkupLine($"[red]Failed to delete .git folder: {Markup.Escape(ex.Message)}[/]");
 
-                        console.WriteException(ex);
+                        ExceptionDisplay.DisplayException(ex, console);
                     }
                 }
             }
@@ -117,7 +118,7 @@ public class WorkspaceDeleter(
         catch (Exception ex)
         {
             console.MarkupLine($"[red]Failed to delete .scribal workspace: {Markup.Escape(ex.Message)}[/]");
-            console.WriteException(ex);
+            ExceptionDisplay.DisplayException(ex, console);
         }
     }
 }

--- a/Scribal.Cli/Interface/ExceptionDisplay.cs
+++ b/Scribal.Cli/Interface/ExceptionDisplay.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using Spectre.Console;
+
+namespace Scribal.Cli.Interface;
+
+public static class ExceptionDisplay
+{
+    /// <summary>
+    ///     AOT-friendly mechanism of writing out exceptions.
+    /// </summary>
+    /// <param name="ex">the exception to display.</param>
+    /// <param name="console">The console to write to.</param>
+    public static void DisplayException(Exception ex, IAnsiConsole? console = null)
+    {
+        console ??= AnsiConsole.Console;
+        
+        console.MarkupLine("[bold red]An error occurred:[/]");
+
+        var panel = new Panel(GetExceptionMarkup(ex)).Header("[yellow]Exception Details[/]")
+                                                     .Border(BoxBorder.Rounded)
+                                                     .BorderColor(Color.Red);
+
+        console.Write(panel);
+    }
+
+    private static Markup GetExceptionMarkup(Exception ex)
+    {
+        var sb = new StringBuilder();
+        var currentException = ex;
+        var exceptionCount = 0;
+
+        while (currentException != null)
+        {
+            if (exceptionCount > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("[grey]---> Inner Exception:[/]");
+            }
+
+            var fullName = currentException.GetType().FullName;
+
+            if (fullName == null)
+            {
+                throw new InvalidOperationException("Exception somehow did not have a sensible type name.");
+            }
+
+            sb.Append($"[bold aqua]{Markup.Escape(fullName)}[/]: ");
+            sb.AppendLine($"[white]{Markup.Escape(currentException.Message)}[/]");
+
+            if (!string.IsNullOrWhiteSpace(currentException.StackTrace))
+            {
+                sb.AppendLine("[dim]Stack Trace:[/]");
+
+                // Escape the stack trace to prevent any accidental markup interpretation
+                // And indent it slightly for readability
+                var enumerable = currentException.StackTrace.Split([
+                        Environment.NewLine
+                    ],
+                    StringSplitOptions.None);
+
+                foreach (var line in enumerable)
+                {
+                    sb.AppendLine($"  [grey]{Markup.Escape(line.Trim())}[/]");
+                }
+            }
+
+            currentException = currentException.InnerException;
+            exceptionCount++;
+        }
+
+        return new(sb.ToString());
+    }
+}

--- a/Scribal.Cli/Interface/StickyTreeSelector.cs
+++ b/Scribal.Cli/Interface/StickyTreeSelector.cs
@@ -61,7 +61,7 @@ public class StickyTreeSelector
         }
         catch (Exception ex)
         {
-            AnsiConsole.WriteException(ex);
+            ExceptionDisplay.DisplayException(ex);
 
             return [];
         }

--- a/Scribal.Cli/Program.cs
+++ b/Scribal.Cli/Program.cs
@@ -23,7 +23,7 @@ IncorporateConfigFromScribalWorkspace(builder);
 
 SetupLogging(builder);
 
-builder.Services.AddScribalAi(builder.Configuration);
+builder.Services.AddScribalAi();
 builder.Services.AddScribal(builder.Configuration, new FileSystem(), TimeProvider.System);
 builder.Services.AddScribalInterface();
 

--- a/Scribal.Cli/Scribal.Cli.csproj
+++ b/Scribal.Cli/Scribal.Cli.csproj
@@ -9,7 +9,7 @@
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
         <PublishReadyToRun>true</PublishReadyToRun>
-        <PublishAot>true</PublishAot>
+        <PublishAot>false</PublishAot>
         <Version>0.2</Version>
     </PropertyGroup>
 

--- a/Scribal.Cli/Scribal.Cli.csproj
+++ b/Scribal.Cli/Scribal.Cli.csproj
@@ -9,6 +9,7 @@
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
         <PublishReadyToRun>true</PublishReadyToRun>
+        <PublishAot>true</PublishAot>
         <Version>0.2</Version>
     </PropertyGroup>
 

--- a/Scribal.Tests/ServiceCollectionTests.cs
+++ b/Scribal.Tests/ServiceCollectionTests.cs
@@ -28,7 +28,7 @@ public class ServiceCollectionTests
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
         services.AddScribal(config, filesystem, new FakeTimeProvider());
-        services.AddScribalAi(config);
+        services.AddScribalAi();
         services.AddScribalInterface();
 
         _ = services.BuildServiceProvider(new ServiceProviderOptions

--- a/Scribal/Config/AiSettings.cs
+++ b/Scribal/Config/AiSettings.cs
@@ -2,14 +2,14 @@ namespace Scribal.Config;
 
 public record ModelSlot
 {
-    public string Provider { get; init; } = default!; // "OpenAI", "Gemini", …
-    public string ModelId { get; init; } = default!;
-    public string? ApiKey { get; init; } // optional if the provider can share
+    public string Provider { get; set; } = default!; // "OpenAI", "Gemini", …
+    public string ModelId { get; set; } = default!;
+    public string? ApiKey { get; set; } // optional if the provider can share
 }
 
 public class AiSettings
 {
-    public ModelSlot? Primary { get; init; } = new();
-    public ModelSlot? Weak { get; init; }
-    public ModelSlot? Embeddings { get; init; }
+    public ModelSlot? Primary { get; set; }
+    public ModelSlot? Weak { get; set; }
+    public ModelSlot? Embeddings { get; set; }
 }

--- a/Scribal/Config/ModelProviders.cs
+++ b/Scribal/Config/ModelProviders.cs
@@ -13,6 +13,15 @@ public interface IModelProvider
 {
     string Name { get; }
     void RegisterServices(IKernelBuilder kb, ModelSlot slot, string serviceSuffix);
+
+    public static void AddModelProviders(IServiceCollection serviceCollection)
+    {
+        // Just do this manually to make it AOT friendly.
+        serviceCollection.AddSingleton<IModelProvider, OpenAIModelProvider>();
+        serviceCollection.AddSingleton<IModelProvider, GeminiModelProvider>();
+        serviceCollection.AddSingleton<IModelProvider, DeepSeekModelProvider>();
+        serviceCollection.AddSingleton<IModelProvider, AnthropicModelProvider>();
+    }
 }
 
 public class OpenAIModelProvider : IModelProvider

--- a/Scribal/JsonDefaults.cs
+++ b/Scribal/JsonDefaults.cs
@@ -1,6 +1,12 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using Scribal.Workspace;
 
 namespace Scribal;
+
+[JsonSourceGenerationOptions(WriteIndented = true, PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(StoryOutline))]
+public partial class ScribalJsonContext : JsonSerializerContext;
 
 public static class JsonDefaults
 {
@@ -9,4 +15,6 @@ public static class JsonDefaults
         WriteIndented = true,
         PropertyNameCaseInsensitive = true
     };
+    
+    public static ScribalJsonContext Context { get; } = new(Default);
 }

--- a/Scribal/JsonDefaults.cs
+++ b/Scribal/JsonDefaults.cs
@@ -6,6 +6,8 @@ namespace Scribal;
 
 [JsonSourceGenerationOptions(WriteIndented = true, PropertyNameCaseInsensitive = true)]
 [JsonSerializable(typeof(StoryOutline))]
+[JsonSerializable(typeof(WorkspaceConfig))]
+[JsonSerializable(typeof(WorkspaceState))]
 public partial class ScribalJsonContext : JsonSerializerContext;
 
 public static class JsonDefaults

--- a/Scribal/Scribal.csproj
+++ b/Scribal/Scribal.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <PublishAot>true</PublishAot>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Scribal/Scribal.csproj
+++ b/Scribal/Scribal.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PublishAot>true</PublishAot>
+        <PublishAot>false</PublishAot>
         <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     </PropertyGroup>
 

--- a/Scribal/Scribal.csproj
+++ b/Scribal/Scribal.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PublishAot>true</PublishAot>
+        <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Scribal/Scribal.csproj
+++ b/Scribal/Scribal.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Anthropic.SDK" Version="5.2.2"/>
+        <PackageReference Include="Anthropic.SDK" Version="5.3.0" />
         <PackageReference Include="LibGit2Sharp" Version="0.31.0"/>
         <PackageReference Include="Markdig" Version="0.41.1"/>
-        <PackageReference Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7"/>
+        <PackageReference Include="Microsoft.Extensions.AI" Version="9.5.0" />
         <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.4.3-preview.1.25230.7"/>
         <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.4.3-preview.1.25230.7"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.3.25171.5"/>
@@ -20,10 +20,10 @@
         <PackageReference Include="Microsoft.KernelMemory.MemoryDb.Qdrant" Version="0.98.250508.3"/>
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.Google" Version="1.48.0-alpha"/>
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.48.0-preview"/>
-        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.49.0"/>
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.51.0" />
         <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.48.0-preview"/>
         <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.48.0-alpha"/>
-        <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.49.0"/>
+        <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.51.0" />
         <PackageReference Include="System.IO.Abstractions" Version="22.0.14"/>
     </ItemGroup>
 

--- a/Scribal/ScribalModelServiceCollectionExtensions.cs
+++ b/Scribal/ScribalModelServiceCollectionExtensions.cs
@@ -47,10 +47,11 @@ public static class ScribalModelServiceCollectionExtensions
                     {
                         var result = SlotsValidator.ValidateSlots(settings, out var error);
                         err = error;
-
+                
                         return result;
                     },
-                    err);
+                    err)
+                ;
 
         services.AddSingleton<Kernel>(sp =>
         {

--- a/Scribal/ScribalModelServiceCollectionExtensions.cs
+++ b/Scribal/ScribalModelServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ namespace Scribal;
 
 public static class ScribalModelServiceCollectionExtensions
 {
+    private const string AiSectionPath = "AI";
+    
     public static void AddScribalAi(this IServiceCollection services, IConfiguration cfg)
     {
         // Register everything that implements IModelProvider.
@@ -34,8 +36,7 @@ public static class ScribalModelServiceCollectionExtensions
         var err = string.Empty;
 
         services.AddOptions<AiSettings>()
-                .Bind(cfg.GetSection("AI"))
-                .ValidateDataAnnotations()
+                .BindConfiguration(AiSectionPath)
                 .Validate(settings =>
                     {
                         var result = SlotsValidator.ValidateSlots(settings, out var error);

--- a/Scribal/ScribalModelServiceCollectionExtensions.cs
+++ b/Scribal/ScribalModelServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
@@ -21,7 +20,7 @@ public static class ScribalModelServiceCollectionExtensions
 {
     private const string AiSectionPath = "AI";
     
-    public static void AddScribalAi(this IServiceCollection services, IConfiguration cfg)
+    public static void AddScribalAi(this IServiceCollection services)
     {
         // Register everything that implements IModelProvider.
         IModelProvider.AddModelProviders(services);

--- a/Scribal/ScribalModelServiceCollectionExtensions.cs
+++ b/Scribal/ScribalModelServiceCollectionExtensions.cs
@@ -21,14 +21,7 @@ public static class ScribalModelServiceCollectionExtensions
     public static void AddScribalAi(this IServiceCollection services, IConfiguration cfg)
     {
         // Register everything that implements IModelProvider.
-        var providerTypes = typeof(IModelProvider).Assembly.GetTypes()
-                                                  .Where(t => typeof(IModelProvider).IsAssignableFrom(t))
-                                                  .Where(t => t is {IsClass: true, IsAbstract: false});
-
-        foreach (var providerType in providerTypes)
-        {
-            services.AddSingleton(typeof(IModelProvider), providerType);
-        }
+        IModelProvider.AddModelProviders(services);
 
         // Register services in the main DI container that the kernel will pull back later.
         services.AddSingleton<FileReader>();

--- a/Scribal/ScribalModelServiceCollectionExtensions.cs
+++ b/Scribal/ScribalModelServiceCollectionExtensions.cs
@@ -37,7 +37,12 @@ public static class ScribalModelServiceCollectionExtensions
         var err = string.Empty;
 
         services.AddOptions<AiSettings>()
-                .BindConfiguration(AiSectionPath)
+                .BindConfiguration(AiSectionPath,
+                    options =>
+                    {
+                        options.BindNonPublicProperties = false;
+                        options.ErrorOnUnknownConfiguration = true;
+                    })
                 .Validate(settings =>
                     {
                         var result = SlotsValidator.ValidateSlots(settings, out var error);

--- a/Scribal/ScribalServiceCollectionExtensions.cs
+++ b/Scribal/ScribalServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class ScribalServiceCollectionExtensions
         IFileSystem fileSystem,
         TimeProvider time)
     {
-        services.Configure<AppConfig>(config.GetSection("AppConfig"));
+        services.Configure<AppConfig>(config.GetSection(nameof(AppConfig)));
 
         // Infrastructure
         services.AddSingleton(fileSystem);

--- a/Scribal/Workspace/ChapterDeletionService.cs
+++ b/Scribal/Workspace/ChapterDeletionService.cs
@@ -109,7 +109,7 @@ public class ChapterDeletionService(
             {
                 var outlineJson = await fileSystem.File.ReadAllTextAsync(plotOutlineFilePath, cancellationToken);
 
-                storyOutline = JsonSerializer.Deserialize<StoryOutline>(outlineJson, JsonDefaults.Default);
+                storyOutline = JsonSerializer.Deserialize<StoryOutline>(outlineJson, JsonDefaults.Context.StoryOutline);
             }
 
             storyOutline ??= new();
@@ -135,7 +135,7 @@ public class ChapterDeletionService(
                 ch.ChapterNumber = newChapterNumber++;
             }
 
-            var updatedOutlineJson = JsonSerializer.Serialize(storyOutline, JsonDefaults.Default);
+            var updatedOutlineJson = JsonSerializer.Serialize(storyOutline, JsonDefaults.Context.StoryOutline);
 
             await fileSystem.File.WriteAllTextAsync(plotOutlineFilePath, updatedOutlineJson, cancellationToken);
             logger.LogInformation("Updated and saved plot_outline.json");

--- a/Scribal/Workspace/WorkspaceManager.cs
+++ b/Scribal/Workspace/WorkspaceManager.cs
@@ -73,7 +73,7 @@ public class WorkspaceManager(
         {
             logger.LogDebug("Writing workspace config to {ConfigPath}", configPath);
 
-            var jsonConfig = JsonSerializer.Serialize(config, JsonDefaults.Default);
+            var jsonConfig = JsonSerializer.Serialize(config, JsonDefaults.Context.WorkspaceConfig);
 
             await fileSystem.File.WriteAllTextAsync(configPath, jsonConfig);
 
@@ -211,7 +211,7 @@ public class WorkspaceManager(
         try
         {
             var json = await fileSystem.File.ReadAllTextAsync(stateFilePath, cancellationToken);
-            var state = JsonSerializer.Deserialize<WorkspaceState>(json);
+            var state = JsonSerializer.Deserialize<WorkspaceState>(json, JsonDefaults.Context.WorkspaceState);
             logger.LogInformation("Workspace state loaded from {StateFilePath}", stateFilePath);
 
             return state;
@@ -247,7 +247,7 @@ public class WorkspaceManager(
 
         try
         {
-            var json = JsonSerializer.Serialize(state, JsonDefaults.Default);
+            var json = JsonSerializer.Serialize(state, JsonDefaults.Context.WorkspaceState);
 
             await fileSystem.File.WriteAllTextAsync(stateFilePath, json, cancellationToken);
             logger.LogInformation("Workspace state saved to {StateFilePath}", stateFilePath);
@@ -283,7 +283,7 @@ public class WorkspaceManager(
         {
             var json = await fileSystem.File.ReadAllTextAsync(plotOutlineFilePath, cancellationToken);
 
-            var outline = JsonSerializer.Deserialize<StoryOutline>(json, JsonDefaults.Default);
+            var outline = JsonSerializer.Deserialize<StoryOutline>(json, JsonDefaults.Context.StoryOutline);
 
             logger.LogInformation("Plot outline loaded from {PlotOutlineFilePath}", plotOutlineFilePath);
 
@@ -318,7 +318,7 @@ public class WorkspaceManager(
 
         try
         {
-            var outlineJson = JsonSerializer.Serialize(outline, JsonDefaults.Default);
+            var outlineJson = JsonSerializer.Serialize(outline, JsonDefaults.Context.StoryOutline);
 
             await fileSystem.File.WriteAllTextAsync(plotOutlineFilePath, outlineJson);
             logger.LogInformation("Plot outline saved to {PlotOutlineFilePath}", plotOutlineFilePath);


### PR DESCRIPTION
This PR clears most of the obvious blockers to running Scribal as an AOT app.

- Configuration is now source-gen'd.
- Ditto System.Text.Json.
- AnsiConsole.WriteException replaced with a nice equivalent.
- Some assembly-scanning for types replaced with manual registration.

To get configuration working, I had to make the properties on my models non-init.

However, actually trying to publish reveals more warnings in libraries I don't control. While it might be possible to get those working, I'm not too concerned about it for now.