### PR TITLE
Fix bugs with workspace and repo deletion

### DIFF
--- a/Scribal.Cli/Features/WorkspaceDeleter.cs
+++ b/Scribal.Cli/Features/WorkspaceDeleter.cs
@@ -41,7 +41,7 @@ public class WorkspaceDeleter(
 
         try
         {
-            fileSystem.Directory.Delete(workspacePath, true);
+            await workspaceManager.DeleteWorkspaceAsync();
 
             console.MarkupLine(
                 $"[green].scribal workspace at '{Markup.Escape(workspacePath)}' deleted successfully.[/]");
@@ -101,8 +101,8 @@ public class WorkspaceDeleter(
 
                     try
                     {
-                        fileSystem.Directory.Delete(gitFolderPath, true);
-
+                        gitService.DeleteRepository();
+                        
                         console.MarkupLine(
                             $"[green].git folder at '{Markup.Escape(gitFolderPath)}' deleted successfully.[/]");
                     }

--- a/Scribal.Cli/Features/WorkspaceDeleter.cs
+++ b/Scribal.Cli/Features/WorkspaceDeleter.cs
@@ -101,7 +101,9 @@ public class WorkspaceDeleter(
 
                     try
                     {
-                        gitService.DeleteRepository();
+                        fileSystem.Directory.Delete(gitFolderPath, recursive: true);
+
+                        gitService.DisableRepository();
                         
                         console.MarkupLine(
                             $"[green].git folder at '{Markup.Escape(gitFolderPath)}' deleted successfully.[/]");

--- a/Scribal.Cli/Interface/InterfaceManager.cs
+++ b/Scribal.Cli/Interface/InterfaceManager.cs
@@ -106,7 +106,7 @@ public class InterfaceManager(
             ? WorkspaceManager.TryFindWorkspaceFolder(fileSystem)
             : "not in workspace";
 
-        var branch = gitService.Enabled ? await gitService.GetCurrentBranch() : "[not in a git repository]";
+        var branch = gitService.Enabled ? await gitService.GetCurrentBranch() : "not in a git repository";
 
         var model = modelId is null ? "[yellow]no model![/]" : $"[yellow]{modelId}[/]";
 

--- a/Scribal/Agency/GitService.cs
+++ b/Scribal/Agency/GitService.cs
@@ -17,7 +17,7 @@ public interface IGitService
     Task<bool> CreateCommitAsync(List<string> files, string message, CancellationToken ct = default);
     Task<bool> CreateCommitAllAsync(string message, CancellationToken ct = default);
     Task CreateGitIgnore(string gitignore);
-    void DeleteRepository();
+    void DisableRepository();
 }
 
 public sealed class GitService(
@@ -183,12 +183,10 @@ public sealed class GitService(
         }
     }
 
-    public void DeleteRepository()
+    public void DisableRepository()
     {
         EnsureValidRepository();
         
-        fileSystem.Directory.Delete(_repo.Info.Path, recursive: true);
-
         _repo = null;
     }
 

--- a/Scribal/Agency/GitService.cs
+++ b/Scribal/Agency/GitService.cs
@@ -17,6 +17,7 @@ public interface IGitService
     Task<bool> CreateCommitAsync(List<string> files, string message, CancellationToken ct = default);
     Task<bool> CreateCommitAllAsync(string message, CancellationToken ct = default);
     Task CreateGitIgnore(string gitignore);
+    void DeleteRepository();
 }
 
 public sealed class GitService(
@@ -180,6 +181,15 @@ public sealed class GitService(
         {
             await fileSystem.File.WriteAllTextAsync(path, gitignore);
         }
+    }
+
+    public void DeleteRepository()
+    {
+        EnsureValidRepository();
+        
+        fileSystem.Directory.Delete(_repo.Info.Path, recursive: true);
+
+        _repo = null;
     }
 
     public void Dispose()

--- a/Scribal/Workspace/WorkspaceManager.cs
+++ b/Scribal/Workspace/WorkspaceManager.cs
@@ -493,18 +493,29 @@ public class WorkspaceManager(
 
             var commitMessage = $"Added new Chapter {ordinal}: {title}";
             var stateFilePath = fileSystem.Path.Join(workspacePath, StateFileName);
-            var filesToCommit = new List<string> { draftFilePath, stateFilePath };
+
+            var filesToCommit = new List<string>
+            {
+                draftFilePath,
+                stateFilePath
+            };
 
             // AI: Use the new overload to commit both the chapter file and the state file
             var commitSuccess = await git.CreateCommitAsync(filesToCommit, commitMessage, cancellationToken);
 
             if (commitSuccess)
             {
-                logger.LogInformation("Successfully committed new chapter file ({ChapterFile}) and state file ({StateFile}) to git", draftFilePath, stateFilePath);
+                logger.LogInformation(
+                    "Successfully committed new chapter file ({ChapterFile}) and state file ({StateFile}) to git",
+                    draftFilePath,
+                    stateFilePath);
             }
             else
             {
-                logger.LogWarning("Failed to commit new chapter file ({ChapterFile}) and/or state file ({StateFile}) to git", draftFilePath, stateFilePath);
+                logger.LogWarning(
+                    "Failed to commit new chapter file ({ChapterFile}) and/or state file ({StateFile}) to git",
+                    draftFilePath,
+                    stateFilePath);
             }
 
             return true;
@@ -516,5 +527,20 @@ public class WorkspaceManager(
             // AI: Attempt to revert state changes if file saving fails? Complex, for now log and return false.
             return false;
         }
+    }
+
+    public Task DeleteWorkspaceAsync()
+    {
+        if (string.IsNullOrEmpty(CurrentWorkspacePath))
+        {
+            throw new InvalidOperationException(
+                "Cannot delete workspace, workspace directory not found or not initialized");
+        }
+
+        fileSystem.Directory.Delete(CurrentWorkspacePath, true);
+
+        _workspace = null;
+
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Deleting the workspace and Git repo caused issues in the WorkspaceManager and GitService.  Both have a property signalling whether they are in a valid state, which was not set by the WorkspaceDeleter.

In turn this caused issues in the interface, which tried to get the HEAD of a non-existent repo, or the folder path of a non-existent workspace.

This PR resolves both issues by delegating the actual deletion of workspaces and repos to their respective services.