### PR TITLE
Remind user of commands when in refinement loop

### DIFF
--- a/Scribal.Cli/Features/ChapterDrafterService.cs
+++ b/Scribal.Cli/Features/ChapterDrafterService.cs
@@ -177,6 +177,9 @@ public class ChapterDrafterService(
             }
 
             console.WriteLine();
+            
+            console.MarkupLine("(available commands: [blue]/done[/], [blue]/cancel[/])");
+
             console.Markup("[green]Refine Chapter Draft > [/]");
             var userInput = ReadLine.Read(); // Assuming ReadLine is accessible or replace with _console.Ask/Prompt
 

--- a/Scribal.Cli/Features/NewChapterCreator.cs
+++ b/Scribal.Cli/Features/NewChapterCreator.cs
@@ -250,7 +250,11 @@ public class NewChapterCreator(
             }
 
             console.WriteLine();
+            
+            console.MarkupLine("(available commands: [blue]/done[/], [blue]/cancel[/])");
+            
             console.Markup("[green]Refine New Chapter Draft > [/]");
+            
             var userInput = ReadLine.Read();
 
             if (string.IsNullOrWhiteSpace(userInput))

--- a/Scribal.Cli/Features/OutlineService.cs
+++ b/Scribal.Cli/Features/OutlineService.cs
@@ -271,7 +271,11 @@ public class OutlineService(
             }
 
             AnsiConsole.WriteLine();
+            
+            AnsiConsole.MarkupLine("(available commands: [blue]/done[/], [blue]/cancel[/])");
+
             AnsiConsole.Markup("[green]Refine Plot Outline > [/]");
+            
             var userInput = ReadLine.Read();
 
             if (string.IsNullOrWhiteSpace(userInput))

--- a/Scribal.Cli/Features/PitchService.cs
+++ b/Scribal.Cli/Features/PitchService.cs
@@ -133,6 +133,9 @@ public class PitchService(
             }
 
             console.WriteLine();
+            
+            console.MarkupLine("(available commands: [blue]/done[/], [blue]/cancel[/])");
+
             console.Markup("[green]Refine Premise > [/]");
             var userInput = ReadLine.Read();
 


### PR DESCRIPTION
Reminds the user of the /done and /cancel commands on every turn of a refinement loop so they do not get lost.

Closes #6.