### PR TITLE
Allow use of existing premise when generating outline

### DIFF
--- a/Scribal.Cli/Features/CommandService.cs
+++ b/Scribal.Cli/Features/CommandService.cs
@@ -34,7 +34,7 @@ public class CommandService(
     private readonly Argument<string> _premiseArgument = new()
     {
         Name = "Premise",
-        Arity = ArgumentArity.ExactlyOne,
+        Arity = ArgumentArity.ZeroOrOne,
         Description = "The story premise to be turned into an outline"
     };
 
@@ -163,14 +163,8 @@ public class CommandService(
     private async Task OutlineCommand(InvocationContext arg)
     {
         var premise = arg.ParseResult.GetValueForArgument(_premiseArgument);
+        
         var token = arg.GetCancellationToken();
-
-        if (string.IsNullOrWhiteSpace(premise))
-        {
-            AnsiConsole.MarkupLine("[red]Premise cannot be empty.[/]");
-
-            return;
-        }
 
         try
         {

--- a/Scribal.Cli/Features/OutlineService.cs
+++ b/Scribal.Cli/Features/OutlineService.cs
@@ -39,6 +39,38 @@ public class OutlineService(
 
         var sid = options.Value.Primary.Provider;
 
+        if (string.IsNullOrWhiteSpace(premise))
+        {
+            var state = await workspaceManager.LoadWorkspaceStateAsync(cancellationToken: ct);
+
+            var existingPremise = state?.Premise;
+
+            if (string.IsNullOrWhiteSpace(existingPremise))
+            {
+                AnsiConsole.MarkupLine("[red]Premise cannot be empty.[/]");
+
+                return;
+            }
+
+            AnsiConsole.WriteLine(existingPremise);
+
+            var useSavedPremise =
+                await AnsiConsole.ConfirmAsync("You have a saved premise. Use this to generate the outline?",
+                    cancellationToken: ct);
+
+            if (useSavedPremise)
+            {
+                premise = existingPremise;
+            }
+            else
+            {
+                AnsiConsole.WriteLine(
+                    "Rerun the /outline command with your desired premise, e.g. '/outline \"a sci-fi epic about a horse\"'.");
+
+                return;
+            }
+        }
+
         var generatedOutlineJson = await GenerateInitialOutline(premise, sid, ct);
 
         if (!TryParseOutline(generatedOutlineJson, out var storyOutline))

--- a/Scribal/Workspace/WorkspaceManager.cs
+++ b/Scribal/Workspace/WorkspaceManager.cs
@@ -303,7 +303,7 @@ public class WorkspaceManager(
         }
     }
 
-    public async Task SavePlotOutlineAsync(StoryOutline outline, string premise)
+    public async Task SavePlotOutlineAsync(StoryOutline outline, string? premise)
     {
         var workspacePath = CurrentWorkspacePath;
 


### PR DESCRIPTION
This PR lets the /outline command automatically pick up on the workspace's saved /premise, if one exists.

If the user supplies a premise anyway, they are given a choice for which to use.

Closes #7.