### PR TITLE
Extract response refinement into own service

### DIFF
--- a/Scribal.Cli/Features/NewChapterCreator.cs
+++ b/Scribal.Cli/Features/NewChapterCreator.cs
@@ -185,7 +185,7 @@ public class NewChapterCreator(
 
         var draftStream = chat.StreamAsync(chatRequest, history, ct);
         var draftBuilder = new StringBuilder();
-        await consoleChatRenderer.StreamWithSpinnerAsync(CollectWhileStreaming(draftStream, draftBuilder, ct), ct);
+        await consoleChatRenderer.StreamWithSpinnerAsync(draftStream.CollectWhileStreaming(draftBuilder, ct), ct);
 
         var generatedDraft = draftBuilder.ToString().Trim();
 
@@ -287,7 +287,7 @@ public class NewChapterCreator(
                 var refinementStream = chat.StreamAsync(chatRequest, refinementHistory, ct);
 
                 await consoleChatRenderer.StreamWithSpinnerAsync(
-                    CollectWhileStreaming(refinementStream, responseBuilder, ct),
+                    refinementStream.CollectWhileStreaming(responseBuilder, ct),
                     ct);
 
                 lastAssistantResponse = responseBuilder.ToString().Trim();
@@ -318,20 +318,5 @@ public class NewChapterCreator(
         }
 
         return lastAssistantResponse;
-    }
-
-    private async IAsyncEnumerable<ChatStreamItem> CollectWhileStreaming(IAsyncEnumerable<ChatStreamItem> stream,
-        StringBuilder collector,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        await foreach (var item in stream.WithCancellation(ct))
-        {
-            if (item is ChatStreamItem.TokenChunk tc)
-            {
-                collector.Append(tc.Content);
-            }
-
-            yield return item;
-        }
     }
 }

--- a/Scribal.Cli/Features/PitchService.cs
+++ b/Scribal.Cli/Features/PitchService.cs
@@ -70,7 +70,7 @@ public class PitchService(
         var premiseBuilder = new StringBuilder();
 
         // Stream the initial premise generation.
-        await consoleChatRenderer.StreamWithSpinnerAsync(CollectWhileStreaming(premiseStream, premiseBuilder, ct), ct);
+        await consoleChatRenderer.StreamWithSpinnerAsync(premiseStream.CollectWhileStreaming(premiseBuilder, ct), ct);
 
         var generatedPremise = premiseBuilder.ToString().Trim();
 
@@ -102,21 +102,5 @@ public class PitchService(
         state.PipelineStage = PipelineStageType.AwaitingOutline;
         await workspaceManager.SaveWorkspaceStateAsync(state, cancellationToken: ct);
         console.MarkupLine("[green]Premise saved and pipeline stage updated to AwaitingOutline.[/]");
-    }
-
-    // Helper to collect content while streaming for the initial premise
-    private async IAsyncEnumerable<ChatStreamItem> CollectWhileStreaming(IAsyncEnumerable<ChatStreamItem> stream,
-        StringBuilder collector,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        await foreach (var item in stream.WithCancellation(ct))
-        {
-            if (item is ChatStreamItem.TokenChunk tc)
-            {
-                collector.Append(tc.Content);
-            }
-
-            yield return item;
-        }
     }
 }

--- a/Scribal.Cli/Infrastructure/RefinementService.cs
+++ b/Scribal.Cli/Infrastructure/RefinementService.cs
@@ -74,7 +74,7 @@ public class RefinementService(
                 var refinementStream = chat.StreamAsync(chatRequest, refinementHistory, ct);
 
                 await consoleChatRenderer.StreamWithSpinnerAsync(
-                    CollectWhileStreaming(refinementStream, responseBuilder, ct),
+                    refinementStream.CollectWhileStreaming(responseBuilder, ct),
                     ct);
 
                 lastAssistantResponse = responseBuilder.ToString().Trim();
@@ -105,20 +105,5 @@ public class RefinementService(
         }
 
         return lastAssistantResponse;
-    }
-    
-    private async IAsyncEnumerable<ChatStreamItem> CollectWhileStreaming(IAsyncEnumerable<ChatStreamItem> stream,
-        StringBuilder collector,
-        [EnumeratorCancellation] CancellationToken ct = default)
-    {
-        await foreach (var item in stream.WithCancellation(ct))
-        {
-            if (item is ChatStreamItem.TokenChunk tc)
-            {
-                collector.Append(tc.Content);
-            }
-
-            yield return item;
-        }
     }
 }

--- a/Scribal.Cli/Infrastructure/RefinementService.cs
+++ b/Scribal.Cli/Infrastructure/RefinementService.cs
@@ -1,0 +1,124 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Scribal.AI;
+using Scribal.Cli.Interface;
+using Spectre.Console;
+
+namespace Scribal.Cli.Infrastructure;
+
+public class RefinementService(
+    IAnsiConsole console,
+    ConsoleChatRenderer consoleChatRenderer,
+    IAiChatService chat,
+    ILogger<RefinementService> logger)
+{
+    public async Task<string> RefineAsync(string input, string systemPrompt, string sid, CancellationToken ct = default)
+    {
+        var refinementCid = $"{Guid.NewGuid()}";
+
+        var refinementHistory = new ChatHistory();
+
+        refinementHistory.AddSystemMessage(systemPrompt);
+        refinementHistory.AddAssistantMessage(input);
+
+        var lastAssistantResponse = input;
+
+        while (true)
+        {
+            if (ct.IsCancellationRequested)
+            {
+                console.MarkupLine("[yellow]Refinement cancelled.[/]");
+                logger.LogInformation("Refinement cancelled by host for {RefinementCid}", refinementCid);
+
+                break;
+            }
+
+            console.WriteLine();
+
+            console.MarkupLine("(available commands: [blue]/done[/], [blue]/cancel[/])");
+
+            console.Markup("[green]Refine > [/]");
+            var userInput = ReadLine.Read();
+
+            if (string.IsNullOrWhiteSpace(userInput))
+            {
+                continue;
+            }
+
+            if (userInput.Equals("/done", StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogInformation("User finished draft refinement for {RefinementCid}", refinementCid);
+
+                return lastAssistantResponse;
+            }
+
+            if (userInput.Equals("/cancel", StringComparison.OrdinalIgnoreCase))
+            {
+                console.MarkupLine("[yellow]Cancelling refinement and using original output...[/]");
+                logger.LogInformation("User cancelled draft refinement for {RefinementCid}", refinementCid);
+
+                return input;
+            }
+
+            console.WriteLine();
+            var responseBuilder = new StringBuilder();
+
+            try
+            {
+                refinementHistory.AddUserMessage(userInput);
+
+                var chatRequest = new ChatRequest(userInput, refinementCid, sid);
+
+                var refinementStream = chat.StreamAsync(chatRequest, refinementHistory, ct);
+
+                await consoleChatRenderer.StreamWithSpinnerAsync(
+                    CollectWhileStreaming(refinementStream, responseBuilder, ct),
+                    ct);
+
+                lastAssistantResponse = responseBuilder.ToString().Trim();
+
+                if (!string.IsNullOrWhiteSpace(lastAssistantResponse))
+                {
+                    refinementHistory.AddAssistantMessage(lastAssistantResponse);
+
+                    logger.LogDebug("Refinement successful for {RefinementCid}, response length {Length}",
+                        refinementCid,
+                        lastAssistantResponse.Length);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                console.WriteLine();
+                console.MarkupLine("[yellow](Refinement stream cancelled)[/]");
+                logger.LogInformation("Refinement stream cancelled for {RefinementCid}", refinementCid);
+
+                break;
+            }
+            catch (Exception e)
+            {
+                ExceptionDisplay.DisplayException(e, console);
+                console.MarkupLine("[red]An error occurred during refinement.[/]");
+                logger.LogError(e, "Error during draft refinement for {RefinementCid}", refinementCid);
+            }
+        }
+
+        return lastAssistantResponse;
+    }
+    
+    private async IAsyncEnumerable<ChatStreamItem> CollectWhileStreaming(IAsyncEnumerable<ChatStreamItem> stream,
+        StringBuilder collector,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var item in stream.WithCancellation(ct))
+        {
+            if (item is ChatStreamItem.TokenChunk tc)
+            {
+                collector.Append(tc.Content);
+            }
+
+            yield return item;
+        }
+    }
+}

--- a/Scribal.Cli/Infrastructure/ScribalInterfaceServiceCollectionExtensions.cs
+++ b/Scribal.Cli/Infrastructure/ScribalInterfaceServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ScribalInterfaceServiceCollectionExtensions
         services.AddSingleton<InterfaceManager>();
         services.AddSingleton<PitchService>();
         services.AddSingleton<OutlineService>();
+        services.AddSingleton<RefinementService>();
         services.AddSingleton<ChapterManagerService>();
         services.AddSingleton<ChapterDrafterService>();
         services.AddSingleton<NewChapterCreator>();

--- a/Scribal.Cli/Interface/ConsoleChatRenderer.cs
+++ b/Scribal.Cli/Interface/ConsoleChatRenderer.cs
@@ -9,7 +9,7 @@ public class ConsoleChatRenderer(IAnsiConsole console)
     ///     Streams an LLM response to the console, showing a spinner
     ///     until the first token is available.
     /// </summary>
-    public async Task StreamWithSpinnerAsync(IAsyncEnumerable<ChatStreamItem> stream, CancellationToken ct = default)
+    public async Task StreamWithSpinnerAsync(IAsyncEnumerable<ChatModels> stream, CancellationToken ct = default)
     {
         // 1. Get an enumerator we can advance manually.
         await using var e = stream.GetAsyncEnumerator(ct);
@@ -54,12 +54,12 @@ public class ConsoleChatRenderer(IAnsiConsole console)
                      .StartAsync("Processing …", async _ => await taskToAwait.WaitAsync(ct));
     }
 
-    private void ProcessChatStreamItem(ChatStreamItem e)
+    private void ProcessChatStreamItem(ChatModels e)
     {
         switch (e)
         {
-            case ChatStreamItem.TokenChunk tc: console.Write(tc.Content); break;
-            case ChatStreamItem.Metadata md:
+            case ChatModels.TokenChunk tc: console.Write(tc.Content); break;
+            case ChatModels.Metadata md:
             {
                 console.WriteLine();
                 console.WriteLine();

--- a/Scribal/AI/AiChatService.cs
+++ b/Scribal/AI/AiChatService.cs
@@ -13,23 +13,6 @@ using ChatMessageContent = Microsoft.SemanticKernel.ChatMessageContent;
 
 namespace Scribal.AI;
 
-/// <summary>
-///     Discriminated union between a chunk of the model's streamed output and a metadata record produced when it's done.
-/// </summary>
-public record ChatStreamItem
-{
-    private ChatStreamItem()
-    {
-    }
-
-    public sealed record TokenChunk(string Content) : ChatStreamItem;
-
-    public sealed record Metadata(TimeSpan Elapsed, int PromptTokens, int CompletionTokens) : ChatStreamItem;
-}
-
-public record ChatMessage(string Message, ChatStreamItem.Metadata Metadata);
-
-public record ChatRequest(string UserMessage, string ConversationId, string ServiceId);
 
 public sealed class AiChatService(
     Kernel kernel,
@@ -39,7 +22,7 @@ public sealed class AiChatService(
     TimeProvider time,
     MetadataCollector metadataCollector) : IAiChatService
 {
-    public async IAsyncEnumerable<ChatStreamItem> StreamAsync(ChatRequest request,
+    public async IAsyncEnumerable<ChatModels> StreamAsync(ChatRequest request,
         ChatHistory? history = null,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
@@ -77,7 +60,7 @@ public sealed class AiChatService(
                 continue;
             }
 
-            var hunk = new ChatStreamItem.TokenChunk(text);
+            var hunk = new ChatModels.TokenChunk(text);
 
             sb.Append(hunk.Content);
 

--- a/Scribal/AI/ChatModels.cs
+++ b/Scribal/AI/ChatModels.cs
@@ -1,0 +1,48 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Scribal.AI;
+
+/// <summary>
+///     Discriminated union between a chunk of the model's streamed output and a metadata record produced when it's done.
+/// </summary>
+public record ChatModels
+{
+    private ChatModels()
+    {
+    }
+
+    public sealed record TokenChunk(string Content) : ChatModels;
+
+    public sealed record Metadata(TimeSpan Elapsed, int PromptTokens, int CompletionTokens) : ChatModels;
+}
+
+public record ChatMessage(string Message, ChatModels.Metadata Metadata);
+
+public record ChatRequest(string UserMessage, string ConversationId, string ServiceId);
+
+public static class ChatModelExtensions
+{
+    /// <summary>
+    /// Collects the output of an asynchronous chat stream while continuing to yield its output. 
+    /// </summary>
+    /// <param name="stream">The chat to stream asynchronously.</param>
+    /// <param name="collector">The StringBuilder which will be given the complete output of the chat message.</param>
+    /// <param name="ct">A token allowing asynchronous cancellation.</param>
+    /// <returns>An asynchronous iteration of the same chat stream.</returns>
+    public static async IAsyncEnumerable<ChatModels> CollectWhileStreaming(
+        this IAsyncEnumerable<ChatModels> stream,
+        StringBuilder collector,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await foreach (var item in stream.WithCancellation(ct))
+        {
+            if (item is ChatModels.TokenChunk tc)
+            {
+                collector.Append(tc.Content);
+            }
+
+            yield return item;
+        }
+    }
+}

--- a/Scribal/AI/IAiChatService.cs
+++ b/Scribal/AI/IAiChatService.cs
@@ -20,7 +20,7 @@ public interface IAiChatService
     ///     An asynchronous stream of discriminated unions, which either represent a chunk of
     ///     the assistant's response or (ultimately) a record of the response's metadata, such as token usage.
     /// </returns>
-    IAsyncEnumerable<ChatStreamItem> StreamAsync(ChatRequest request,
+    IAsyncEnumerable<ChatModels> StreamAsync(ChatRequest request,
         ChatHistory? history = null,
         CancellationToken ct = default);
 

--- a/Scribal/AI/MetadataCollector.cs
+++ b/Scribal/AI/MetadataCollector.cs
@@ -9,7 +9,7 @@ namespace Scribal.AI;
 
 public class MetadataCollector(TimeProvider timeProvider, ILogger<MetadataCollector> logger)
 {
-    public ChatStreamItem.Metadata CollectMetadata(string? sid, long startTimestamp, ChatMessageContent message)
+    public ChatModels.Metadata CollectMetadata(string? sid, long startTimestamp, ChatMessageContent message)
     {
         var elapsed = timeProvider.GetElapsedTime(startTimestamp);
         var promptTokens = 0;
@@ -40,7 +40,7 @@ public class MetadataCollector(TimeProvider timeProvider, ILogger<MetadataCollec
                 message.Metadata);
         }
 
-        var metadata = new ChatStreamItem.Metadata(elapsed, promptTokens, completionTokens);
+        var metadata = new ChatModels.Metadata(elapsed, promptTokens, completionTokens);
 
         logger.LogDebug(
             "Final metadata for SID '{Sid}': Elapsed: {Elapsed}, PromptTokens: {PromptTokens}, CompletionTokens: {CompletionTokens}",


### PR DESCRIPTION
Right now the various drafting features which have a refinement loop (telling the AI to change its work) all implement their own versions.

This PR introduces a RefinementService which consolidates this work into one place.

The OutlineService has been exempted from this, because it does things slightly differently.

I should be able to abstract over that (have the RefinementService take in a Func<Task<string>> or whatever), but leaving that for later.