### PR TITLE
Display chunks of prose in a more pleasing way

### DIFF
--- a/Scribal.Cli/Features/ChapterManagerService.cs
+++ b/Scribal.Cli/Features/ChapterManagerService.cs
@@ -221,7 +221,8 @@ public class ChapterManagerService(
 
             if (!string.IsNullOrWhiteSpace(selectedChapter.Summary))
             {
-                AnsiConsole.MarkupLine($"Summary: [grey]{Markup.Escape(selectedChapter.Summary)}[/]");
+                AnsiConsole.Console.DisplayProsePassage(selectedChapter.Summary, "Summary");
+                //AnsiConsole.MarkupLine($"Summary: [grey]{Markup.Escape(selectedChapter.Summary)}[/]");
             }
 
             AnsiConsole.MarkupLine(

--- a/Scribal.Cli/Features/CommandService.cs
+++ b/Scribal.Cli/Features/CommandService.cs
@@ -307,9 +307,14 @@ public class CommandService(
 
         AnsiConsole.MarkupLine($"[green]Current Pipeline Stage:[/] {state.PipelineStage.ToString()}");
 
-        AnsiConsole.MarkupLine(!string.IsNullOrWhiteSpace(state.Premise)
-            ? $"[green]Premise:[/] {state.Premise}"
-            : "[green]Premise:[/] Not set");
+        if (string.IsNullOrWhiteSpace(state.Premise))
+        {
+            AnsiConsole.MarkupLine("[green]Premise:[/] Not set");
+        }
+        else
+        {
+            AnsiConsole.Console.DisplayProsePassage(state.Premise, "Premise");
+        }
 
         AnsiConsole.MarkupLine(!string.IsNullOrWhiteSpace(state.PlotOutlineFile)
             ? $"[green]Plot Outline File:[/] {state.PlotOutlineFile}"

--- a/Scribal.Cli/Features/OutlineService.cs
+++ b/Scribal.Cli/Features/OutlineService.cs
@@ -135,7 +135,8 @@ public class OutlineService(
         if (userSuppliedAPremise && workspaceHasPremise)
         {
             var selectionPrompt = new SelectionPrompt<string>()
-                                  .Title("You supplied a premise, but your workspace already has one. Pick which one to use:")
+                                  .Title(
+                                      "You supplied a premise, but your workspace already has one. Pick which one to use:")
                                   .PageSize(3)
                                   .AddChoices("my existing premise", "the premise I just supplied");
 
@@ -143,13 +144,13 @@ public class OutlineService(
 
             return response is "my existing premise" ? existingPremise : premise;
         }
-        
+
         if (!userSuppliedAPremise && workspaceHasPremise)
         {
-            AnsiConsole.WriteLine(existingPremise!);
+            AnsiConsole.Console.DisplayProsePassage(existingPremise!, "Existing premise");
 
             AnsiConsole.WriteLine();
-            
+
             var useSavedPremise =
                 await AnsiConsole.ConfirmAsync("You have a saved premise. Use this to generate the outline?",
                     cancellationToken: ct);
@@ -169,12 +170,14 @@ public class OutlineService(
         {
             return premise;
         }
-        
+
         if (!userSuppliedAPremise && !workspaceHasPremise)
         {
             AnsiConsole.MarkupLine("[red]Premise cannot be empty.[/]");
             AnsiConsole.MarkupLine("[yellow]Either use the /pitch command to generate one,[/]");
-            AnsiConsole.MarkupLine("[yellow]or rerun the /outline command with your desired premise, e.g. '/outline \"a sci-fi epic about a horse\"'.[/]");
+
+            AnsiConsole.MarkupLine(
+                "[yellow]or rerun the /outline command with your desired premise, e.g. '/outline \"a sci-fi epic about a horse\"'.[/]");
 
             return null;
         }
@@ -338,11 +341,11 @@ public class OutlineService(
             }
 
             AnsiConsole.WriteLine();
-            
+
             AnsiConsole.MarkupLine("(available commands: [blue]/done[/], [blue]/cancel[/])");
 
             AnsiConsole.Markup("[green]Refine Plot Outline > [/]");
-            
+
             var userInput = ReadLine.Read();
 
             if (string.IsNullOrWhiteSpace(userInput))

--- a/Scribal.Cli/Interface/ProseDisplay.cs
+++ b/Scribal.Cli/Interface/ProseDisplay.cs
@@ -6,7 +6,9 @@ public static class ProseDisplay
 {
     public static void DisplayProsePassage(this IAnsiConsole console, string prose, string header)
     {
-        var panel = new Panel(prose).Header($"[yellow]{header}[/]")
+        var clean = Markup.Escape(prose);
+        
+        var panel = new Panel(clean).Header($"[yellow]{header}[/]")
                                     .Border(BoxBorder.Rounded)
                                     .BorderColor(Color.Green);
 

--- a/Scribal.Cli/Interface/ProseDisplay.cs
+++ b/Scribal.Cli/Interface/ProseDisplay.cs
@@ -1,0 +1,15 @@
+using Spectre.Console;
+
+namespace Scribal.Cli.Interface;
+
+public static class ProseDisplay
+{
+    public static void DisplayProsePassage(this IAnsiConsole console, string prose, string header)
+    {
+        var panel = new Panel(prose).Header($"[yellow]{header}[/]")
+                                    .Border(BoxBorder.Rounded)
+                                    .BorderColor(Color.Green);
+
+        console.Write(panel);
+    }
+}


### PR DESCRIPTION
This PR Introduces a small service to handle displaying large passages of prose. Right now they're just spat out into the terminal with no demarcation.

Now, the ProseDisplay will put it in a nice panel with a header.