### PR TITLE
Improve the Git service

### DIFF
--- a/Scribal.Cli/App.cs
+++ b/Scribal.Cli/App.cs
@@ -25,10 +25,7 @@ public static class App
         {
             await ingestor.IngestAllMarkdown(cwd, SearchOption.AllDirectories);
         }
-
-        var git = app.Services.GetRequiredService<IGitService>();
-        git.Initialise(filesystem.Directory.GetCurrentDirectory());
-
+        
         var manager = app.Services.GetRequiredService<InterfaceManager>();
 
         await manager.DisplayWelcome();

--- a/Scribal.Cli/Features/CommandService.cs
+++ b/Scribal.Cli/Features/CommandService.cs
@@ -21,7 +21,7 @@ public class CommandService(
     WorkspaceDeleter workspaceDeleter,
     WorkspaceManager workspaceManager,
     ChapterManagerService chapterManagerService,
-    IGitService gitService,
+    IGitServiceFactory gitFactory,
     ExportService exportService)
 {
     private readonly Argument<string> _ideaArgument = new()
@@ -188,7 +188,7 @@ public class CommandService(
             return;
         }
 
-        if (!gitService.Enabled)
+        if (!gitFactory.TryOpenRepository(out var git))
         {
             AnsiConsole.MarkupLine("[yellow]Git is not initialized for this workspace. Cannot commit.[/]");
 
@@ -198,7 +198,8 @@ public class CommandService(
         try
         {
             AnsiConsole.MarkupLine($"Attempting to commit all changes with message: \"{message}\"...");
-            var success = await gitService.CreateCommitAllAsync(message, token);
+            
+            var success = await git.CreateCommitAllAsync(message, token);
 
             AnsiConsole.MarkupLine(success
                 ? "[green]Commit operation completed. Check logs for details.[/]"

--- a/Scribal.Tests/Features/ExportServiceTests.cs
+++ b/Scribal.Tests/Features/ExportServiceTests.cs
@@ -16,7 +16,7 @@ public class ExportServiceTests
     private readonly MockFileSystem _fileSystem = new();
     private readonly IAnsiConsole _console = Substitute.For<IAnsiConsole>();
     private readonly ExportService _sut;
-    private readonly IGitService _gitService = Substitute.For<IGitService>();
+    private readonly IGitServiceFactory _gitFactory = Substitute.For<IGitServiceFactory>();
     private readonly IUserInteraction _userInteraction = Substitute.For<IUserInteraction>();
 
     private const string TestProjectRootDir = "/test/project";
@@ -27,7 +27,7 @@ public class ExportServiceTests
     public ExportServiceTests()
     {
         var workspaceManager = new WorkspaceManager(_fileSystem,
-            _gitService,
+            _gitFactory,
             _userInteraction,
             Options.Create(new AppConfig()),
             NullLogger<WorkspaceManager>.Instance);
@@ -377,7 +377,7 @@ public class ExportServiceTests
         localFileSystem.Directory.SetCurrentDirectory(TestProjectRootDir);
 
         var localWorkspaceManager = new WorkspaceManager(localFileSystem,
-            Substitute.For<IGitService>(),
+            Substitute.For<IGitServiceFactory>(),
             Substitute.For<IUserInteraction>(),
             Options.Create(new AppConfig()),
             NullLogger<WorkspaceManager>.Instance);

--- a/Scribal.Tests/Features/WorkspaceDeleterTests.cs
+++ b/Scribal.Tests/Features/WorkspaceDeleterTests.cs
@@ -99,30 +99,6 @@ public class WorkspaceDeleterTests
     }
 
     [Fact]
-    public async Task DeleteWorkspaceCommandAsync_DeletesScribalAndGitFolders_WhenUserConfirmsBoth()
-    {
-        // Arrange
-        InitializeTestSetup(gitEnabled: true);
-        SetupBasicWorkspace();
-        SetupGitRepository();
-        _userInteraction.ConfirmAsync(Arg.Is<string>(s => s.Contains(".scribal"))).Returns(Task.FromResult(true));
-        _userInteraction.ConfirmAsync(Arg.Is<string>(s => s.Contains(".git"))).Returns(Task.FromResult(true));
-
-        _git.CreateCommitAsync(TestScribalDir, Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
-
-        var invocationContext = CreateTestInvocationContext();
-
-        // Act
-        await _sut.DeleteWorkspaceCommandAsync(invocationContext);
-
-        // Assert
-        await Verify(_fileSystem.AllPaths)
-              .UseDirectory("Snapshots")
-              .UseFileName("WorkspaceDeleter_DeletesScribalAndGit");
-    }
-
-    [Fact]
     public async Task DeleteWorkspaceCommandAsync_DeletesScribal_SkipsGitFolder_WhenUserDeclinesGitDeletion()
     {
         // Arrange

--- a/Scribal.Tests/ServiceCollectionTests.cs
+++ b/Scribal.Tests/ServiceCollectionTests.cs
@@ -25,7 +25,7 @@ public class ServiceCollectionTests
                                                .Build();
 
         services.AddSingleton<IConfiguration>(config);
-        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddLogging();
 
         services.AddScribal(config, filesystem, new FakeTimeProvider());
         services.AddScribalAi();

--- a/Scribal.Tests/Workspace/ChapterDeletionServiceTests.cs
+++ b/Scribal.Tests/Workspace/ChapterDeletionServiceTests.cs
@@ -36,7 +36,7 @@ public class ChapterDeletionServiceTests
         _fileSystem.Directory.SetCurrentDirectory(currentDirectory); // Important for TryFindWorkspaceFolder
 
         _workspaceManager = new(_fileSystem,
-            Substitute.For<IGitService>(),
+            Substitute.For<IGitServiceFactory>(),
             Substitute.For<IUserInteraction>(),
             Options.Create(new AppConfig()),
             NullLogger<WorkspaceManager>.Instance);

--- a/Scribal/Agency/GitCommitFilter.cs
+++ b/Scribal/Agency/GitCommitFilter.cs
@@ -7,7 +7,7 @@ using Scribal.Config;
 namespace Scribal.Agency;
 
 public sealed class GitCommitFilter(
-    IGitService git,
+    IGitServiceFactory factory,
     CommitGenerator generator,
     IOptions<AiSettings> aiSettings,
     ILogger<GitCommitFilter> logger) : IFunctionInvocationFilter
@@ -18,7 +18,7 @@ public sealed class GitCommitFilter(
         // Let the real function run first.
         await next(ctx);
 
-        if (!git.Enabled)
+        if (!factory.TryOpenRepository(out var git))
         {
             return;
         }

--- a/Scribal/Agency/GitService.cs
+++ b/Scribal/Agency/GitService.cs
@@ -66,6 +66,12 @@ public class GitServiceFactory(
 
     public void DeleteRepository(string repoPath)
     {
+        if (!Repository.IsValid(repoPath))
+        {
+            throw new ArgumentException("Path was not a valid Git repo.", nameof(repoPath));
+        }
+
+        fileSystem.Directory.Delete(repoPath, true);
     }
 }
 

--- a/Scribal/Infrastructure/ScribalServiceCollectionExtensions.cs
+++ b/Scribal/Infrastructure/ScribalServiceCollectionExtensions.cs
@@ -46,6 +46,6 @@ public static class ScribalServiceCollectionExtensions
         // Other
         services.AddSingleton<CommitGenerator>();
         services.AddSingleton(TimeProvider.System);
-        services.AddSingleton<IGitService, GitService>();
+        services.AddSingleton<IGitServiceFactory, GitServiceFactory>();
     }
 }

--- a/Scribal/Scribal.csproj
+++ b/Scribal/Scribal.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="Microsoft.SemanticKernel.Plugins.Memory" Version="1.48.0-alpha"/>
         <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.51.0"/>
         <PackageReference Include="System.IO.Abstractions" Version="22.0.14"/>
+        <PackageReference Include="ValueOf" Version="2.0.31" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Scribal/Workspace/ChapterDrafterService.cs
+++ b/Scribal/Workspace/ChapterDrafterService.cs
@@ -18,7 +18,7 @@ public class ChapterDrafterService(
     IOptions<AiSettings> options,
     IFileSystem fileSystem,
     WorkspaceManager workspaceManager,
-    IGitService gitService,
+    IGitServiceFactory factory,
     TimeProvider time,
     IUserInteraction userInteraction,
     IRefinementService refinementService,
@@ -252,7 +252,7 @@ public class ChapterDrafterService(
 
     private async Task AttemptGitCommit(ChapterState chapter, string draftFilePath, CancellationToken cancellationToken)
     {
-        if (!gitService.Enabled)
+        if (!factory.TryOpenRepository(out var git))
         {
             logger.LogInformation("Git service not enabled. Skipping commit for chapter {ChapterNumber} draft",
                 chapter.Number);
@@ -262,7 +262,7 @@ public class ChapterDrafterService(
 
         var commitMessage = $"Drafted Chapter {chapter.Number}: {chapter.Title}";
 
-        var commitSuccess = await gitService.CreateCommitAsync(draftFilePath, commitMessage, cancellationToken);
+        var commitSuccess = await git.CreateCommitAsync(draftFilePath, commitMessage, cancellationToken);
 
         if (commitSuccess)
         {


### PR DESCRIPTION
Avoids half-initialisation problems with the Git service by breaking initialisation out into a factory, ditto deconstruction.

Removed a test that was a pain to get working due to LibGit2Sharp being annoying to mock.